### PR TITLE
Include UUID in gather data

### DIFF
--- a/lib/gather/collector.rb
+++ b/lib/gather/collector.rb
@@ -152,14 +152,14 @@ module Gather
 
       # Generate unique UUID
       if File.file?('/etc/machine-id')
-        machine_id = File.read('/etc/machine-id')
+        machine_id = File.read('/etc/machine-id').chomp
       elsif File.file?('/var/lib/dbus/machine-id')
-        machine_id = File.read('/var/lib/dbus/machine-id')
+        machine_id = File.read('/var/lib/dbus/machine-id').chomp
       else
         root_mount = File.read('/proc/mounts').split("\n").find{ |mount| mount.split[1] == '/' }.split.first
-        machine_id = `lsblk #{root_mount} -f -o UUID -n`
+        machine_id = `lsblk #{root_mount} -f -o UUID -n`.chomp
       end
-      first_mac = data[:network].values[0][:mac]
+      first_mac = `lshw -c network  2>/dev/null |grep -m 1 'serial:' |sed 's/.*serial: //g;s/://g'`.chomp
       data[:uuid] = Digest::MD5.hexdigest "#{machine_id}#{first_mac}\n"
 
       data

--- a/lib/gather/collector.rb
+++ b/lib/gather/collector.rb
@@ -150,6 +150,18 @@ module Gather
                           'Metal'
                         end
 
+      # Generate unique UUID
+      if File.file?('/etc/machine-id')
+        machine_id = File.read('/etc/machine-id')
+      elsif File.file?('/var/lib/dbus/machine-id')
+        machine_id = File.read('/var/lib/dbus/machine-id')
+      else
+        root_mount = File.read('/proc/mounts').split("\n").find{ |mount| mount.split[1] == '/' }.split.first
+        machine_id = `lsblk #{root_mount} -f -o UUID -n`
+      end
+      first_mac = data[:network][0][:mac]
+      data[:uuid] = `echo "#{machine_id}#{first_mac}" |md5sum |awk '{print $1}'`
+
       data
     end
 

--- a/lib/gather/collector.rb
+++ b/lib/gather/collector.rb
@@ -159,8 +159,8 @@ module Gather
         root_mount = File.read('/proc/mounts').split("\n").find{ |mount| mount.split[1] == '/' }.split.first
         machine_id = `lsblk #{root_mount} -f -o UUID -n`
       end
-      first_mac = data[:network][0][:mac]
-      data[:uuid] = `echo "#{machine_id}#{first_mac}" |md5sum |awk '{print $1}'`
+      first_mac = data[:network].values[0][:mac]
+      data[:uuid] = Digest::MD5.hexdigest "#{machine_id}#{first_mac}\n"
 
       data
     end


### PR DESCRIPTION
This PR enables Gather to generate a unique ID for each machine it is used on. This is the same algorithm as is used in the Carbon Client script of the Carbon Leaderboard and so will match the UUIDs generated by that script.